### PR TITLE
Update README and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<p align="center">
-  <h1 align="center">Cilium Performance</h1>
-  <p align="center">
-    <p align="center">A repo dedicated to Cilium performance testing and evaluation.</p>
-  </p>
-</p>
+# Cilium Performance
+
+A repo dedicated to Cilium performance testing and evaluation.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
-# cilium-perf-test
-
-Cilium performance evaluation repo.
+<p align="center">
+  <h1 align="center">Cilium Performance</h1>
+  <p align="center">
+    <p align="center">A repo dedicated to Cilium performance testing and evaluation.</p>
+  </p>
+</p>

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,9 +1,9 @@
 # Shared manifests
 
-This is cilium version agnostic set of manifests that can be used as part of
+This is a Cilium version agnostic set of manifests that can be used as part of
 the perf evaluation.
 
 File | Description
 -----|------------
-boutique_100.yaml | Google's miscroservices demo with 100 concurrent users
-boutique_500.yaml | Google's miscroservices demo with 500 concurrent users
+boutique_100.yaml | Google's microservices demo with 100 concurrent users
+boutique_500.yaml | Google's microservices demo with 500 concurrent users


### PR DESCRIPTION
- Tidies up `README.md`
- Fixes typo `miscroservices` to `microservices` in `shared/README.md`

Signed-off-by: Stacy Kim <stacy.kim@ucla.edu>